### PR TITLE
Transaction and block page changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ app.locals.Decimal = Decimal;
 app.locals.utils = utils;
 
 var genesisAsset = env.genesisAsset;
-if (typeof genesisAsset == 'undefined') {
+if (!(env.genesisAsset)) {
     genesisAsset = "ASSET";
 }
 app.locals.genesisAsset = genesisAsset;

--- a/app.js
+++ b/app.js
@@ -28,11 +28,10 @@ app.locals.Decimal = Decimal;
 app.locals.utils = utils;
 
 var genesisAsset = env.genesisAsset;
+if (typeof genesisAsset == 'undefined') {
+    genesisAsset = "ASSET";
+}
 app.locals.genesisAsset = genesisAsset;
-app.locals.assets = {};
-
-// Currently include testnet assets - Should be configured appropriately for any mainnet issuance
-app.locals.assets["cad5765e6f54ceb51c0366e4e349e5fbbfabcefadecf8fc3b614514784c0c2f2"] =  genesisAsset; // for 3-of-5 testnet
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
@@ -66,24 +65,6 @@ var db = mongoose.connection;
 db.on("error", function(err) {
     console.error(err);
     process.exit(0);
-});
-db.once("open", function(callback) {
-    console.log("Connection succeeded.");
-
-    // get genesis asset hash
-    dbApi.get_block_height(0).then(function(blockByHeight) {
-        if (blockByHeight && blockByHeight.getblock.tx.length > 1) {
-            dbApi.get_tx(blockByHeight.getblock.tx[1]).then(function(tx) {
-                if (tx && tx.getrawtransaction.vin[0].issuance) {
-                    app.locals.assets[tx.getrawtransaction.vin[0].issuance.asset] = genesisAsset; // add asset hex as genesis asset
-                }
-            }).catch(function(err) {
-                console.log("genesis issuance tx missing")
-            });
-        }
-    }).catch(function(err) {
-        console.log("genesis block missing")
-    });
 });
 
 // connect to MongDB - should automatically try to reconnect if connection fails

--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ app.locals.moment = moment;
 app.locals.Decimal = Decimal;
 app.locals.utils = utils;
 
-var genesisAsset = "CBT";
+var genesisAsset = env.genesisAsset;
 app.locals.genesisAsset = genesisAsset;
 app.locals.assets = {};
 

--- a/app.js
+++ b/app.js
@@ -33,8 +33,6 @@ app.locals.assets = {};
 
 // Currently include testnet assets - Should be configured appropriately for any mainnet issuance
 app.locals.assets["cad5765e6f54ceb51c0366e4e349e5fbbfabcefadecf8fc3b614514784c0c2f2"] =  genesisAsset; // for 3-of-5 testnet
-global.dummy_assets = ['BTC', 'ETH', 'XRP', 'BCH', 'EOS', 'LTC', 'XLM', 'ADA', 'TRX',
-                        'MIOTA', 'GOLD', 'SILVER', 'GAS', 'OIL', 'COPPER', 'PLATINUM'];
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));

--- a/helpers/env.js
+++ b/helpers/env.js
@@ -6,7 +6,7 @@
 module.exports = {
     // For testnet/mainnet ribbon display
 	testnet: true,
-
+    genesisAsset: process.env.GENESIS_ASSET,
     // Connection details for the Ocean node
     // Any bitcoin-like RPC blockchains are supported
     ocean:{

--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -71,27 +71,9 @@ function formatBytes(bytesInt) {
 	return bytesInt + " B";
 }
 
-// Dummy asset method used for demo purposes on testnet
-function getDummyAsset(hex) {
-	// dummy assets - will be replaced by actual asset - asset hash pairs in main net release
-	if (!hex) {
-		return "";
-	}
-
-	var sum = 0;
-	for (var i = 0; i < hex.length; i++) {
-		c = hex[i];
-		if ('0123456789'.indexOf(c) !== -1) {
-			sum += parseInt(c);
-		}
-	}
-	return dummy_assets[sum % dummy_assets.length]
-}
-
 module.exports = {
 	hex2ascii: hex2ascii,
 	splitArrayIntoChunks: splitArrayIntoChunks,
 	getRandomString: getRandomString,
 	formatBytes: formatBytes,
-	getDummyAsset: getDummyAsset
 };

--- a/public/css/styling.css
+++ b/public/css/styling.css
@@ -241,6 +241,12 @@
  .tag-fee {
      background-color: #FF0000;
 }
+ .tag-policy {
+     background-color: #00FFFF;
+}
+ .tag-lockedmulti {
+     background-color: #778899;
+}
  .tag-null {
      background-color: #C0C0C0;
 }

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -137,7 +137,11 @@ div(class="tab-content")
                                             td(class="monospace") #{genesisAsset}
                                             td(class="monospace") #{new Decimal(0)}
                                     else if (vin.issuance)
-                                        - asset = (vin.issuance['asset'] in assets) ? (assets[vin.issuance['asset']]) : "ASSET";
+                                        - var asset = genesisAsset
+                                        if (vin.issuance.assetlabel)
+                                            - asset = vin.issuance.assetlabel;
+                                        else if (vin.issuance['asset'] in assets)
+                                            - asset = (assets[vin.issuance['asset']]);
                                         tr
                                             th #{(txInputIndex)}
                                             td
@@ -149,7 +153,11 @@ div(class="tab-content")
                                             td(class="monospace") #{new Decimal(vin.issuance.assetamount)}
 
                                     else if (vin.prev_out)
-                                        - asset = (vin.prev_out['asset'] in assets) ? (assets[vin.prev_out['asset']]) : "ASSET";
+                                        - var asset = genesisAsset
+                                        if (vin.prev_out.assetlabel)
+                                            - asset = vin.prev_out.assetlabel;
+                                        else if (vin.prev_out['asset'] in assets)
+                                            - asset = (assets[vin.prev_out['asset']]);
                                         tr
                                             th #{(txInputIndex)}
                                             td
@@ -217,16 +225,19 @@ div(class="tab-content")
                                                             span()
                                             td
                                                 if (tx.vin[0].coinbase)
-                                                    if vout.value > 0
-                                                        - asset = (vout['asset'] in assets) ? (assets[vout['asset']]) : "ASSET";
-                                                        span(class="monospace") #{asset}
-                                                    else
-                                                        span(class="monospace") #{genesisAsset}
+                                                    - var asset = genesisAsset
+                                                    if (vout.assetlabel)
+                                                        - asset = vout.assetlabel;
+                                                    span(class="monospace") #{asset}
                                                 else
                                                     if tx.tokenAsset && vout.asset == tx.tokenAsset
-                                                        span(class="tag tag-reissuance monospace") token
+                                                        span(class="tag tag-reissuance monospace") #{genesisAsset}
                                                     else
-                                                        - asset = (vout['asset'] in assets) ? (assets[vout['asset']]) : "ASSET";
+                                                        - var asset = genesisAsset
+                                                        if (vout.assetlabel)
+                                                            - asset = vout.assetlabel;
+                                                        else if (vout['asset'] in assets)
+                                                            - asset = (assets[vout['asset']]);
                                                         span(class="monospace") #{asset}
                                             td
                                                 if (vout.value)

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -137,7 +137,7 @@ div(class="tab-content")
                                             td(class="monospace") #{genesisAsset}
                                             td(class="monospace") #{new Decimal(0)}
                                     else if (vin.issuance)
-                                        - asset = (vin.issuance['asset'] in assets) ? (assets[vin.issuance['asset']]) : (utils.getDummyAsset(vin.issuance['asset']));
+                                        - asset = (vin.issuance['asset'] in assets) ? (assets[vin.issuance['asset']]) : "ASSET";
                                         tr
                                             th #{(txInputIndex)}
                                             td
@@ -149,7 +149,7 @@ div(class="tab-content")
                                             td(class="monospace") #{new Decimal(vin.issuance.assetamount)}
 
                                     else if (vin.prev_out)
-                                        - asset = (vin.prev_out['asset'] in assets) ? (assets[vin.prev_out['asset']]) : (utils.getDummyAsset(vin.prev_out['asset']));
+                                        - asset = (vin.prev_out['asset'] in assets) ? (assets[vin.prev_out['asset']]) : "ASSET";
                                         tr
                                             th #{(txInputIndex)}
                                             td
@@ -218,7 +218,7 @@ div(class="tab-content")
                                             td
                                                 if (tx.vin[0].coinbase)
                                                     if vout.value > 0
-                                                        - asset = (vout['asset'] in assets) ? (assets[vout['asset']]) : (utils.getDummyAsset(vout['asset']));
+                                                        - asset = (vout['asset'] in assets) ? (assets[vout['asset']]) : "ASSET";
                                                         span(class="monospace") #{asset}
                                                     else
                                                         span(class="monospace") #{genesisAsset}
@@ -226,7 +226,7 @@ div(class="tab-content")
                                                     if tx.tokenAsset && vout.asset == tx.tokenAsset
                                                         span(class="tag tag-reissuance monospace") token
                                                     else
-                                                        - asset = (vout['asset'] in assets) ? (assets[vout['asset']]) : (utils.getDummyAsset(vout['asset']));
+                                                        - asset = (vout['asset'] in assets) ? (assets[vout['asset']]) : "ASSET";
                                                         span(class="monospace") #{asset}
                                             td
                                                 if (vout.value)

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -202,6 +202,10 @@ div(class="tab-content")
                                                             div(class="monospace", style="word-break: break-word;") #{vout.scriptPubKey.addresses[0]}
                                                     else if (vout.scriptPubKey.type == 'fee')
                                                         span(class="tag tag-fee monospace") fees
+						    else if (vout.scriptPubKey.type == 'registeraddress')
+							span(class="tag tag-policy monospace") registeraddress
+						    else if (vout.scriptPubKey.type == 'lockedmultisig')
+							span(class="tag tag-lockedmulti monospace") lockedmultisig
                                                     else if (vout.scriptPubKey.asm && vout.scriptPubKey.asm.startsWith('OP_RETURN '))
                                                         div(class="monospace", style="word-break: break-word;")
                                                             span(class="monospace") OP_RETURN:

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -140,8 +140,6 @@ div(class="tab-content")
                                         - var asset = genesisAsset
                                         if (vin.issuance.assetlabel)
                                             - asset = vin.issuance.assetlabel;
-                                        else if (vin.issuance['asset'] in assets)
-                                            - asset = (assets[vin.issuance['asset']]);
                                         tr
                                             th #{(txInputIndex)}
                                             td
@@ -156,8 +154,6 @@ div(class="tab-content")
                                         - var asset = genesisAsset
                                         if (vin.prev_out.assetlabel)
                                             - asset = vin.prev_out.assetlabel;
-                                        else if (vin.prev_out['asset'] in assets)
-                                            - asset = (assets[vin.prev_out['asset']]);
                                         tr
                                             th #{(txInputIndex)}
                                             td
@@ -236,8 +232,6 @@ div(class="tab-content")
                                                         - var asset = genesisAsset
                                                         if (vout.assetlabel)
                                                             - asset = vout.assetlabel;
-                                                        else if (vout['asset'] in assets)
-                                                            - asset = (assets[vout['asset']]);
                                                         span(class="monospace") #{asset}
                                             td
                                                 if (vout.value)

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -162,7 +162,7 @@ div(class="tab-content")
                                                 if (vin.prev_out.value)
                                                     span(class="monospace") #{vin.prev_out.value}
                                                 else
-                                                    if (!vin.coinbase)
+                                                    if (!vin.asset)
                                                         include unblind-modal.pug
                                                     else
                                                         span(class="monospace") #{new Decimal(0)}
@@ -232,7 +232,7 @@ div(class="tab-content")
                                                 if (vout.value)
                                                     span(class="monospace") #{vout.value}
                                                 else
-                                                    if (!tx.vin[0].coinbase)
+                                                    if (!vout.asset)
                                                         include unblind-modal.pug
                                                     else
                                                         span(class="monospace") #{new Decimal(0)}

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -209,7 +209,12 @@ div(class="tab-content")
                                                     else if (vout.scriptPubKey.type == 'registeraddress')
                                                         span(class="tag tag-policy monospace") registeraddress
                                                     else if (vout.scriptPubKey.type == 'lockedmultisig')
-                                                        span(class="tag tag-lockedmulti monospace") lockedmultisig
+                                                        if (vout.request)
+                                                            span(class="tag tag-lockedmulti monospace") Request
+                                                        else if (vout.bid)
+                                                            span(class="tag tag-lockedmulti monospace") Bid
+                                                        else
+                                                            span(class="tag tag-lockedmulti monospace") lockedmultisig
                                                     else if (vout.scriptPubKey.asm && vout.scriptPubKey.asm.startsWith('OP_RETURN '))
                                                         div(class="monospace", style="word-break: break-word;")
                                                             span(class="monospace") OP_RETURN:

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -202,10 +202,10 @@ div(class="tab-content")
                                                             div(class="monospace", style="word-break: break-word;") #{vout.scriptPubKey.addresses[0]}
                                                     else if (vout.scriptPubKey.type == 'fee')
                                                         span(class="tag tag-fee monospace") fees
-						    else if (vout.scriptPubKey.type == 'registeraddress')
-							span(class="tag tag-policy monospace") registeraddress
-						    else if (vout.scriptPubKey.type == 'lockedmultisig')
-							span(class="tag tag-lockedmulti monospace") lockedmultisig
+                                                    else if (vout.scriptPubKey.type == 'registeraddress')
+                                                        span(class="tag tag-policy monospace") registeraddress
+                                                    else if (vout.scriptPubKey.type == 'lockedmultisig')
+                                                        span(class="tag tag-lockedmulti monospace") lockedmultisig
                                                     else if (vout.scriptPubKey.asm && vout.scriptPubKey.asm.startsWith('OP_RETURN '))
                                                         div(class="monospace", style="word-break: break-word;")
                                                             span(class="monospace") OP_RETURN:

--- a/views/transaction.pug
+++ b/views/transaction.pug
@@ -192,10 +192,10 @@ block content
                                                                     span #{vout.scriptPubKey.addresses[0]}
                                                         else if (vout.scriptPubKey.type == 'fee')
                                                             span(class="tag tag-fee monospace") fees
-							else if (vout.scriptPubKey.type == 'registeraddress')
-							    span(class="tag tag-policy monospace") registeraddress
-							else if (vout.scriptPubKey.type == 'lockedmultisig')
-							    span(class="tag tag-lockedmulti monospace") lockedmultisig
+														else if (vout.scriptPubKey.type == 'registeraddress')
+															span(class="tag tag-policy monospace") registeraddress
+														else if (vout.scriptPubKey.type == 'lockedmultisig')
+															span(class="tag tag-lockedmulti monospace") lockedmultisig
                                                         else if (vout.scriptPubKey.asm && vout.scriptPubKey.asm.startsWith('OP_RETURN '))
                                                             div(class="monospace", style="word-break: break-word;")
                                                                 span(class="monospace") OP_RETURN:

--- a/views/transaction.pug
+++ b/views/transaction.pug
@@ -192,6 +192,10 @@ block content
                                                                     span #{vout.scriptPubKey.addresses[0]}
                                                         else if (vout.scriptPubKey.type == 'fee')
                                                             span(class="tag tag-fee monospace") fees
+							else if (vout.scriptPubKey.type == 'registeraddress')
+							    span(class="tag tag-policy monospace") registeraddress
+							else if (vout.scriptPubKey.type == 'lockedmultisig')
+							    span(class="tag tag-lockedmulti monospace") lockedmultisig
                                                         else if (vout.scriptPubKey.asm && vout.scriptPubKey.asm.startsWith('OP_RETURN '))
                                                             div(class="monospace", style="word-break: break-word;")
                                                                 span(class="monospace") OP_RETURN:

--- a/views/transaction.pug
+++ b/views/transaction.pug
@@ -132,7 +132,7 @@ block content
                                                 td(class="monospace") #{genesisAsset}
                                                 td(class="monospace") #{new Decimal(0)}
                                         else if (vin.issuance)
-                                            - asset = (vin.issuance['asset'] in assets) ? (assets[vin.issuance['asset']]) : (utils.getDummyAsset(vin.issuance['asset']));
+                                            - asset = (vin.issuance['asset'] in assets) ? (assets[vin.issuance['asset']]) : "ASSET";
                                             tr
                                                 th #{(txInputIndex)}
                                                 td
@@ -144,7 +144,7 @@ block content
                                                     span(class="monospace") #{asset}
                                                 td(class="monospace") #{new Decimal(vin.issuance.assetamount)}
                                         else if (vin.prev_out)
-                                            - asset = (vin.prev_out['asset'] in assets) ? (assets[vin.prev_out['asset']]) : (utils.getDummyAsset(vin.prev_out['asset']));
+                                            - asset = (vin.prev_out['asset'] in assets) ? (assets[vin.prev_out['asset']]) : "ASSET";
                                             tr
                                                 th #{(txInputIndex)}
                                                 td
@@ -208,7 +208,7 @@ block content
                                                 td
                                                     if (result.transaction.vin[0].coinbase)
                                                         if vout.value > 0
-                                                            - asset = (vout.asset in assets) ? (assets[vout.asset]) : (utils.getDummyAsset(vout.asset));
+                                                            - asset = (vout.asset in assets) ? (assets[vout.asset]) : "ASSET";
                                                             span(class="monospace") #{asset}
                                                         else
                                                             span(class="monospace") #{genesisAsset}
@@ -216,7 +216,7 @@ block content
                                                         if result.transaction.tokenAsset && vout.asset == result.transaction.tokenAsset
                                                             span(class="tag tag-reissuance monospace") token
                                                         else
-                                                            - asset = (vout.asset in assets) ? (assets[vout.asset]) : (utils.getDummyAsset(vout.asset));
+                                                            - asset = (vout.asset in assets) ? (assets[vout.asset]) : "ASSET";
                                                             span(class="monospace") #{asset}
                                                 td
                                                     if (vout.value)

--- a/views/transaction.pug
+++ b/views/transaction.pug
@@ -199,7 +199,12 @@ block content
                                                         else if (vout.scriptPubKey.type == 'registeraddress')
                                                             span(class="tag tag-policy monospace") registeraddress
                                                         else if (vout.scriptPubKey.type == 'lockedmultisig')
-                                                            span(class="tag tag-lockedmulti monospace") lockedmultisig
+                                                            if (vout.request)
+                                                                span(class="tag tag-lockedmulti monospace") Request
+                                                            else if (vout.bid)
+                                                                span(class="tag tag-lockedmulti monospace") Bid
+                                                            else
+                                                                span(class="tag tag-lockedmulti monospace") lockedmultisig
                                                         else if (vout.scriptPubKey.asm && vout.scriptPubKey.asm.startsWith('OP_RETURN '))
                                                             div(class="monospace", style="word-break: break-word;")
                                                                 span(class="monospace") OP_RETURN:

--- a/views/transaction.pug
+++ b/views/transaction.pug
@@ -135,8 +135,6 @@ block content
                                             - var asset = genesisAsset
                                             if (vin.issuance.assetlabel)
                                                 - asset = vin.issuance.assetlabel;
-                                            else if (vin.issuance['asset'] in assets)
-                                                - asset = (assets[vin.issuance['asset']]);
                                             tr
                                                 th #{(txInputIndex)}
                                                 td
@@ -151,8 +149,6 @@ block content
                                             - var asset = genesisAsset
                                             if (vin.prev_out.assetlabel)
                                                 - asset = vin.prev_out.assetlabel;
-                                            else if (vin.prev_out['asset'] in assets)
-                                                - asset = (assets[vin.prev_out['asset']]);
                                             tr
                                                 th #{(txInputIndex)}
                                                 td
@@ -226,8 +222,6 @@ block content
                                                             - var asset = genesisAsset
                                                             if (vout.assetlabel)
                                                                 - asset = vout.assetlabel;
-                                                            else if (voutv.asset in assets)
-                                                                - asset = (assets[vout.asset]);
                                                             span(class="monospace") #{asset}
                                                 td
                                                     if (vout.value)

--- a/views/transaction.pug
+++ b/views/transaction.pug
@@ -158,7 +158,7 @@ block content
                                                     if (vin.prev_out.value)
                                                         span(class="monospace") #{vin.prev_out.value}
                                                     else
-                                                        if (vin.coinbase)
+                                                        if (!vin.asset)
                                                             include includes/unblind-modal.pug
                                                         else
                                                             span(class="monospace") #{new Decimal(0)}
@@ -192,10 +192,10 @@ block content
                                                                     span #{vout.scriptPubKey.addresses[0]}
                                                         else if (vout.scriptPubKey.type == 'fee')
                                                             span(class="tag tag-fee monospace") fees
-														else if (vout.scriptPubKey.type == 'registeraddress')
-															span(class="tag tag-policy monospace") registeraddress
-														else if (vout.scriptPubKey.type == 'lockedmultisig')
-															span(class="tag tag-lockedmulti monospace") lockedmultisig
+                                                        else if (vout.scriptPubKey.type == 'registeraddress')
+                                                            span(class="tag tag-policy monospace") registeraddress
+                                                        else if (vout.scriptPubKey.type == 'lockedmultisig')
+                                                            span(class="tag tag-lockedmulti monospace") lockedmultisig
                                                         else if (vout.scriptPubKey.asm && vout.scriptPubKey.asm.startsWith('OP_RETURN '))
                                                             div(class="monospace", style="word-break: break-word;")
                                                                 span(class="monospace") OP_RETURN:
@@ -222,7 +222,7 @@ block content
                                                     if (vout.value)
                                                         span(class="monospace") #{vout.value}
                                                     else
-                                                        if (!result.transaction.vin[0].coinbase)
+                                                        if (!vout.asset)
                                                             include includes/unblind-modal.pug
                                                         else
                                                             span(class="monospace") #{new Decimal(0)}

--- a/views/transaction.pug
+++ b/views/transaction.pug
@@ -132,7 +132,11 @@ block content
                                                 td(class="monospace") #{genesisAsset}
                                                 td(class="monospace") #{new Decimal(0)}
                                         else if (vin.issuance)
-                                            - asset = (vin.issuance['asset'] in assets) ? (assets[vin.issuance['asset']]) : "ASSET";
+                                            - var asset = genesisAsset
+                                            if (vin.issuance.assetlabel)
+                                                - asset = vin.issuance.assetlabel;
+                                            else if (vin.issuance['asset'] in assets)
+                                                - asset = (assets[vin.issuance['asset']]);
                                             tr
                                                 th #{(txInputIndex)}
                                                 td
@@ -144,7 +148,11 @@ block content
                                                     span(class="monospace") #{asset}
                                                 td(class="monospace") #{new Decimal(vin.issuance.assetamount)}
                                         else if (vin.prev_out)
-                                            - asset = (vin.prev_out['asset'] in assets) ? (assets[vin.prev_out['asset']]) : "ASSET";
+                                            - var asset = genesisAsset
+                                            if (vin.prev_out.assetlabel)
+                                                - asset = vin.prev_out.assetlabel;
+                                            else if (vin.prev_out['asset'] in assets)
+                                                - asset = (assets[vin.prev_out['asset']]);
                                             tr
                                                 th #{(txInputIndex)}
                                                 td
@@ -207,16 +215,19 @@ block content
                                                                 span()
                                                 td
                                                     if (result.transaction.vin[0].coinbase)
-                                                        if vout.value > 0
-                                                            - asset = (vout.asset in assets) ? (assets[vout.asset]) : "ASSET";
-                                                            span(class="monospace") #{asset}
-                                                        else
-                                                            span(class="monospace") #{genesisAsset}
+                                                        - var asset = genesisAsset
+                                                        if (vout.assetlabel)
+                                                            - asset = vout.assetlabel;
+                                                        span(class="monospace") #{asset}
                                                     else
                                                         if result.transaction.tokenAsset && vout.asset == result.transaction.tokenAsset
-                                                            span(class="tag tag-reissuance monospace") token
+                                                            span(class="tag tag-reissuance monospace") #{genesisAsset}
                                                         else
-                                                            - asset = (vout.asset in assets) ? (assets[vout.asset]) : "ASSET";
+                                                            - var asset = genesisAsset
+                                                            if (vout.assetlabel)
+                                                                - asset = vout.assetlabel;
+                                                            else if (voutv.asset in assets)
+                                                                - asset = (assets[vout.asset]);
                                                             span(class="monospace") #{asset}
                                                 td
                                                     if (vout.value)


### PR DESCRIPTION
I have added display for registeraddress, lockedmultisig (bid and request) transactions. Additionally, the explorer now uses "ASSET" for all default non-policy assets which can be changed as an env variable genesisAsset. The policy assets use their respective labels which have been added to the getrawtransaction rpc. Removed unblind option for registeraddress transactions (bug).

Fixes #5 